### PR TITLE
removed trailing spaces

### DIFF
--- a/companies/515196731.json
+++ b/companies/515196731.json
@@ -5,7 +5,7 @@
   "size": "s",
   "logoFile": "logos/copyleaks_technologies-logo.webp",
   "websiteUrl": "https://copyleaks.com/",
-  "careersUrl": "https://copyleaks.com/careers  ",
+  "careersUrl": "https://copyleaks.com/careers",
   "isHiring": false,
   "linkedinId": "copyleaks",
   "crunchbaseId": "copyleaks-plagiarism-checker",


### PR DESCRIPTION
removed trailing spaces to make the link clickable (may be needed for other links as well)
![תמונה](https://github.com/user-attachments/assets/de56860a-43d7-4c16-ba99-a09bf52e2a49)
